### PR TITLE
Add elasticsearch and redis to sources in dashboard page

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -25,6 +25,18 @@ export default function App() {
                     element: <DashboardPage/>
                 },
                 {
+                    path: "/dashboard",
+                    element: <DashboardPage/>,
+                    children: [
+                        {
+                            path: "/dashboard/queue",
+                        },
+                        {
+                            path: "/dashboard/elasticsearch"
+                        }
+                    ]
+                },
+                {
                     path: "/tenants",
                     element: <TenantsPage/>
                 },

--- a/src/components/dashboard/elasticsearchClusterList.tsx
+++ b/src/components/dashboard/elasticsearchClusterList.tsx
@@ -1,0 +1,60 @@
+import List from "@mui/material/List";
+import {ListSubheader} from "@mui/material";
+import Divider from "@mui/material/Divider";
+import ListItem from "@mui/material/ListItem";
+import ListItemText from "@mui/material/ListItemText";
+import DashboardPaperCard from "../ui/dashboardPaperCard.tsx";
+
+export default function ElasticsearchClusterList() {
+
+    const MOCK_DATA: {
+        [key: string]: string | number | boolean
+    } = {
+        "cluster_name": "cluster",
+        "status": "green",
+        "timed_out": false,
+        "number_of_nodes": 4,
+        "number_of_data_nodes": 3,
+        "active_primary_shards": 346,
+        "active_shards": 693,
+        "relocating_shards": 0,
+        "initializing_shards": 0,
+        "unassigned_shards": 0,
+        "delayed_unassigned_shards": 0,
+        "number_of_pending_tasks": 0,
+        "number_of_in_flight_fetch": 0,
+        "task_max_waiting_in_queue_millis": 0,
+        "active_shards_percent_as_number": 100
+    }
+
+    const listItems = []
+
+    for (const key in MOCK_DATA) {
+        const keyData = MOCK_DATA[key].toString()
+
+        const item = <>
+            <Divider/>
+            <ListItem>
+                <ListItemText primary={key.replace(/_/gi, " ")}/>
+                <ListItemText sx={{textAlign: "right"}} primary={keyData}/>
+            </ListItem>
+        </>
+
+        listItems.push(item)
+    }
+
+    return (
+        <DashboardPaperCard sx={{
+            width: "100%",
+            height: "100%",
+            maxHeight: "600px",
+            padding: "1rem 2rem",
+            overflow: "scroll"
+        }}>
+            <List subheader={
+                <ListSubheader disableSticky={true}>Elasticsearch Info</ListSubheader>}>
+                {listItems.map(item => item)}
+            </List>
+        </DashboardPaperCard>
+    )
+}

--- a/src/components/dashboard/elasticsearchStatsPanel.tsx
+++ b/src/components/dashboard/elasticsearchStatsPanel.tsx
@@ -1,0 +1,97 @@
+import {IRefreshData, IStatsPanel} from "../../types/ui/statsPanel";
+import {AxiosResponse} from "axios";
+import {IValidationError} from "../../types/api/api";
+import {CircularProgress, ListSubheader, Paper} from "@mui/material";
+import DashboardNavbar from "./dashboardNavbar.tsx";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemText from "@mui/material/ListItemText";
+import DashboardPaperCard from "../ui/dashboardPaperCard.tsx";
+
+interface IElasticsearchStatsPanel extends IStatsPanel<AxiosResponse<object, IValidationError> | undefined> {
+    refreshData: IRefreshData
+}
+
+export default function ElasticsearchStatsPanel({data, status, fetchStatus, refreshData}: IElasticsearchStatsPanel) {
+
+    const MOCK_DATA = {
+        "cluster_name": "cluster",
+        "status": "green",
+        "timed_out": false,
+        "number_of_nodes": 4,
+        "number_of_data_nodes": 3,
+        "active_primary_shards": 346,
+        "active_shards": 693,
+        "relocating_shards": 0,
+        "initializing_shards": 0,
+        "unassigned_shards": 0,
+        "delayed_unassigned_shards": 0,
+        "number_of_pending_tasks": 0,
+        "number_of_in_flight_fetch": 0,
+        "task_max_waiting_in_queue_millis": 0,
+        "active_shards_percent_as_number": 100
+    }
+
+    if (status == "pending") {
+        return (
+            <Paper sx={{width: "100%", height: "100%", display: "flex", justifyContent: "center", alignItems: "center"}}
+                   square={false}>
+                <CircularProgress/>
+            </Paper>
+        )
+    }
+
+    if (status == "error" || !data) {
+        return <Paper sx={{width: "100%", height: "100%"}} square={false}>
+            <Typography variant={"h2"}>Could not get data.</Typography>
+        </Paper>
+    }
+
+    const listItems = []
+
+    for (const key in MOCK_DATA) {
+        const item = <>
+            <Divider/>
+            <ListItem>
+                <ListItemText primary={key.replace(/_/gi, " ")}/>
+                <ListItemText sx={{textAlign: "right"}} primary={MOCK_DATA[key].toString()}/>
+            </ListItem>
+        </>
+
+        listItems.push(item)
+    }
+
+    return (
+        <Paper sx={{
+            width: "100%",
+            height: "100%",
+            padding: "0 2rem 1rem 2rem",
+            display: "flex",
+            flexDirection: "column",
+            gap: "2rem"
+        }} square={false}>
+            <Box>
+                <DashboardNavbar refreshTime={refreshData.time} onRefreshTimeChange={refreshData.onChange}
+                                 fetchStatus={fetchStatus}/>
+                <Divider/>
+            </Box>
+            <DashboardPaperCard sx={{
+                width: "100%",
+                height: "100%",
+                maxHeight: "600px",
+                padding: "1rem 2rem",
+                overflow: "scroll"
+            }}>
+                <List subheader={
+                    <ListSubheader disableSticky={true}>Elasticsearch Info</ListSubheader>
+                }>
+                    {listItems.map(item => item)}
+                </List>
+            </DashboardPaperCard>
+
+        </Paper>
+    )
+}

--- a/src/components/dashboard/elasticsearchStatsPanel.tsx
+++ b/src/components/dashboard/elasticsearchStatsPanel.tsx
@@ -1,39 +1,18 @@
 import {IRefreshData, IStatsPanel} from "../../types/ui/statsPanel";
 import {AxiosResponse} from "axios";
 import {IValidationError} from "../../types/api/api";
-import {CircularProgress, ListSubheader, Paper} from "@mui/material";
+import {CircularProgress, Paper} from "@mui/material";
 import DashboardNavbar from "./dashboardNavbar.tsx";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
-import List from "@mui/material/List";
-import ListItem from "@mui/material/ListItem";
-import ListItemText from "@mui/material/ListItemText";
-import DashboardPaperCard from "../ui/dashboardPaperCard.tsx";
+import ElasticsearchClusterList from "./elasticsearchClusterList.tsx";
 
 interface IElasticsearchStatsPanel extends IStatsPanel<AxiosResponse<object, IValidationError> | undefined> {
     refreshData: IRefreshData
 }
 
 export default function ElasticsearchStatsPanel({data, status, fetchStatus, refreshData}: IElasticsearchStatsPanel) {
-
-    const MOCK_DATA = {
-        "cluster_name": "cluster",
-        "status": "green",
-        "timed_out": false,
-        "number_of_nodes": 4,
-        "number_of_data_nodes": 3,
-        "active_primary_shards": 346,
-        "active_shards": 693,
-        "relocating_shards": 0,
-        "initializing_shards": 0,
-        "unassigned_shards": 0,
-        "delayed_unassigned_shards": 0,
-        "number_of_pending_tasks": 0,
-        "number_of_in_flight_fetch": 0,
-        "task_max_waiting_in_queue_millis": 0,
-        "active_shards_percent_as_number": 100
-    }
 
     if (status == "pending") {
         return (
@@ -50,20 +29,6 @@ export default function ElasticsearchStatsPanel({data, status, fetchStatus, refr
         </Paper>
     }
 
-    const listItems = []
-
-    for (const key in MOCK_DATA) {
-        const item = <>
-            <Divider/>
-            <ListItem>
-                <ListItemText primary={key.replace(/_/gi, " ")}/>
-                <ListItemText sx={{textAlign: "right"}} primary={MOCK_DATA[key].toString()}/>
-            </ListItem>
-        </>
-
-        listItems.push(item)
-    }
-
     return (
         <Paper sx={{
             width: "100%",
@@ -78,20 +43,7 @@ export default function ElasticsearchStatsPanel({data, status, fetchStatus, refr
                                  fetchStatus={fetchStatus}/>
                 <Divider/>
             </Box>
-            <DashboardPaperCard sx={{
-                width: "100%",
-                height: "100%",
-                maxHeight: "600px",
-                padding: "1rem 2rem",
-                overflow: "scroll"
-            }}>
-                <List subheader={
-                    <ListSubheader disableSticky={true}>Elasticsearch Info</ListSubheader>
-                }>
-                    {listItems.map(item => item)}
-                </List>
-            </DashboardPaperCard>
-
+            <ElasticsearchClusterList/>
         </Paper>
     )
 }

--- a/src/components/dashboard/queueStatsPanel.tsx
+++ b/src/components/dashboard/queueStatsPanel.tsx
@@ -1,7 +1,7 @@
 import Paper from "@mui/material/Paper";
 import Grid from "@mui/material/Grid";
 import ConnectionGauge from "./connectionGauge.tsx";
-import {CircularProgress, SelectChangeEvent} from "@mui/material";
+import {CircularProgress} from "@mui/material";
 import Typography from "@mui/material/Typography";
 import BacklogCard from "./backlogCard.tsx";
 import DashboardNavbar from "./dashboardNavbar.tsx";
@@ -11,19 +11,14 @@ import {AxiosResponse} from "axios";
 import {IValidationError} from "../../types/api/api";
 import SubscriptionsList from "./subscriptionsList.tsx";
 import Box from "@mui/material/Box";
+import {IRefreshData, IStatsPanel} from "../../types/ui/statsPanel";
 
-interface IStatsPanel {
-    status: "success" | "pending" | "error",
-    fetchStatus: "fetching" | "idle" | "paused"
-    data: AxiosResponse<IQueueStats, IValidationError> | undefined,
+interface IQueueStatsPanel extends IStatsPanel<AxiosResponse<IQueueStats, IValidationError> | undefined> {
     maxRate: number,
-    refreshData: {
-        time: number,
-        onChange: (e: SelectChangeEvent<number>) => void
-    }
+    refreshData: IRefreshData
 }
 
-export default function StatsPanel({data, status, maxRate, refreshData, fetchStatus}: IStatsPanel) {
+export default function QueueStatsPanel({data, status, maxRate, refreshData, fetchStatus}: IQueueStatsPanel) {
 
     if (status == "pending") {
         return (

--- a/src/components/dashboard/sourceConnectionCard.tsx
+++ b/src/components/dashboard/sourceConnectionCard.tsx
@@ -1,6 +1,8 @@
 import {Box, Typography, Button, Stack} from "@mui/material"
 import {Circle} from "@mui/icons-material";
 import DashboardPaperCard from "../ui/dashboardPaperCard.tsx";
+import {useTheme} from "@mui/material/styles";
+import {useSearchParams} from "react-router-dom";
 
 type ConnectionStatus = "success" | "pending" | "error" | "idle"
 type DominatingColor = "success" | "warning" | "error"
@@ -8,7 +10,7 @@ type DominatingColor = "success" | "warning" | "error"
 interface IConnectionCard {
     label: string,
     connectionStatus: ConnectionStatus,
-    onClick: () => void,
+    onBtnClick: () => void,
 }
 
 function getStatusObject(status: ConnectionStatus): { color: DominatingColor, text: string } {
@@ -40,19 +42,39 @@ function getStatusObject(status: ConnectionStatus): { color: DominatingColor, te
     }
 }
 
-export default function SourceConnectionCard({label, connectionStatus, onClick}: IConnectionCard) {
+export default function SourceConnectionCard({label, connectionStatus, onBtnClick}: IConnectionCard) {
 
-    const {text, color} = getStatusObject(connectionStatus)
+    const {palette, } = useTheme()
+    const [searchParams, setSearchParams] = useSearchParams()
+
+    const {text, color,} = getStatusObject(connectionStatus)
     const isLoading = connectionStatus === "pending" || connectionStatus === "idle"
 
+    const isActive = searchParams.get("source") === label
+
+    const activeColor = isActive ? palette.secondary[palette.mode] : palette.background.default
+
+    const clickHandler = () => {
+        setSearchParams(prev => {
+            return {
+                ...prev,
+                "source": label
+            }
+        })
+    }
+
     return (
-        <DashboardPaperCard sx={{padding: "1rem 1.4rem"}}>
-            <Stack direction={"row"} alignItems={"center"} justifyContent={"space-between"} spacing={1}>
+        <DashboardPaperCard sx={{padding: "1rem 1.4rem", cursor: "pointer", bgcolor: activeColor}}>
+            <Stack onClick={clickHandler} direction={"row"} alignItems={"center"} justifyContent={"space-between"}
+                   spacing={1}>
                 <Typography variant={"subtitle1"}>{label}</Typography>
                 <Box sx={{display: "flex", gap: "0.8rem", alignItems: "center", marginLeft: "100%"}}>
                     <Circle color={color}/>
                     <Typography>{text}</Typography>
-                    <Button onClick={onClick} variant={"text"} disabled={isLoading} size={"small"}>Test</Button>
+                    <Button onClick={(e) => {
+                        e.stopPropagation()
+                        onBtnClick()
+                    }} variant={"text"} disabled={isLoading} size={"small"}>Test</Button>
                 </Box>
             </Stack>
         </DashboardPaperCard>

--- a/src/components/dashboard/sourceConnectionCard.tsx
+++ b/src/components/dashboard/sourceConnectionCard.tsx
@@ -44,7 +44,7 @@ function getStatusObject(status: ConnectionStatus): { color: DominatingColor, te
 
 export default function SourceConnectionCard({label, connectionStatus, onBtnClick}: IConnectionCard) {
 
-    const {palette, } = useTheme()
+    const {palette,} = useTheme()
     const [searchParams, setSearchParams] = useSearchParams()
 
     const {text, color,} = getStatusObject(connectionStatus)
@@ -64,8 +64,9 @@ export default function SourceConnectionCard({label, connectionStatus, onBtnClic
     }
 
     return (
-        <DashboardPaperCard sx={{padding: "1rem 1.4rem", cursor: "pointer", bgcolor: activeColor}}>
-            <Stack onClick={clickHandler} direction={"row"} alignItems={"center"} justifyContent={"space-between"}
+        <DashboardPaperCard onClick={clickHandler}
+                            sx={{padding: "1rem 1.4rem", cursor: "pointer", bgcolor: activeColor}}>
+            <Stack direction={"row"} alignItems={"center"} justifyContent={"space-between"}
                    spacing={1}>
                 <Typography variant={"subtitle1"}>{label}</Typography>
                 <Box sx={{display: "flex", gap: "0.8rem", alignItems: "center", marginLeft: "100%"}}>

--- a/src/components/dashboard/sourcesPanel.tsx
+++ b/src/components/dashboard/sourcesPanel.tsx
@@ -1,10 +1,10 @@
 import {Stack} from "@mui/material";
 import SourceConnectionCard from "./sourceConnectionCard.tsx";
 import Paper from "@mui/material/Paper";
-import {ISources} from "../../pages/dashboardPage.tsx";
+import {ISource} from "../../pages/dashboardPage.tsx";
 
 interface ISourcesPanel {
-    sources: ISources[],
+    sources: ISource[],
 }
 
 export default function SourcesPanel({sources}: ISourcesPanel) {
@@ -13,9 +13,9 @@ export default function SourcesPanel({sources}: ISourcesPanel) {
         <Paper square={false} sx={{minWidth: "360px", height: "100%", padding: "1rem"}}>
             <Stack spacing={2}>
                 {sources.map((source) => {
-                    return <SourceConnectionCard key={source.id} label={source.label}
+                    return <SourceConnectionCard key={source.label} label={source.label}
                                                  connectionStatus={source.connectionStatus}
-                                                 onClick={() => {
+                                                 onBtnClick={() => {
                                                      source.testConnection()
                                                  }}/>
                 })}

--- a/src/components/ui/dashboardPaperCard.tsx
+++ b/src/components/ui/dashboardPaperCard.tsx
@@ -1,11 +1,12 @@
 import Paper, {PaperProps} from "@mui/material/Paper";
 import {useTheme} from "@mui/material/styles";
 
-export default function DashboardPaperCard({sx, children, square = false}: PaperProps) {
+export default function DashboardPaperCard(props: PaperProps) {
     const {palette} = useTheme()
+    const {sx, children, square = false} = props
 
     return (
-        <Paper sx={{bgcolor: palette.background.default, ...sx}} square={square}>
+        <Paper {...props} sx={{bgcolor: palette.background.default, ...sx}} square={square}>
             {children}
         </Paper>
     )

--- a/src/components/ui/dashboardPaperCard.tsx
+++ b/src/components/ui/dashboardPaperCard.tsx
@@ -1,15 +1,7 @@
-import Paper from "@mui/material/Paper";
-import {ReactNode} from "react";
-import {SxProps, Theme} from "@mui/system";
+import Paper, {PaperProps} from "@mui/material/Paper";
 import {useTheme} from "@mui/material/styles";
 
-interface DashboardPaperCard {
-    children?: ReactNode,
-    sx?: SxProps<Theme>,
-    square?: boolean
-}
-
-export default function DashboardPaperCard({sx, children, square = false}: DashboardPaperCard) {
+export default function DashboardPaperCard({sx, children, square = false}: PaperProps) {
     const {palette} = useTheme()
 
     return (

--- a/src/lib/api/connection/getDefaultInfo.ts
+++ b/src/lib/api/connection/getDefaultInfo.ts
@@ -1,6 +1,6 @@
-import {fetchWithToken} from "../fetchWithToken.ts";
+import {fetchWithToken} from "../../fetchWithToken.ts";
 
-interface IGetDefaultInfo {
+export interface IGetDefaultInfo {
     prefixUrl: string,
     accessToken: string
 }

--- a/src/lib/api/connection/getElasticsearchInfo.ts
+++ b/src/lib/api/connection/getElasticsearchInfo.ts
@@ -1,0 +1,8 @@
+import {fetchWithToken} from "../../fetchWithToken.ts";
+import {IGetDefaultInfo} from "./getDefaultInfo.ts";
+
+export function getElasticsearchInfo({prefixUrl, accessToken}: IGetDefaultInfo) {
+    const url = `${prefixUrl}/elasticsearch/info`
+
+    return fetchWithToken({url, accessToken})
+}

--- a/src/lib/api/connection/getRedisInfo.ts
+++ b/src/lib/api/connection/getRedisInfo.ts
@@ -1,0 +1,8 @@
+import {fetchWithToken} from "../../fetchWithToken.ts";
+import {IGetDefaultInfo} from "./getDefaultInfo.ts";
+
+export function getRedisInfo({prefixUrl, accessToken}: IGetDefaultInfo) {
+    const url = `${prefixUrl}/redis/info`
+
+    return fetchWithToken({url, accessToken})
+}

--- a/src/pages/dashboardPage.tsx
+++ b/src/pages/dashboardPage.tsx
@@ -1,19 +1,22 @@
 import Box from "@mui/material/Box";
-import {useEffect, useState} from "react";
-import StatsPanel from "../components/dashboard/statsPanel.tsx";
+import {useEffect, useMemo, useState} from "react";
+import QueueStatsPanel from "../components/dashboard/queueStatsPanel.tsx";
 import useConnection from "../lib/api/connection/useConnection.ts";
 import {getQueueStats} from "../lib/api/queue/getQueueStats.ts";
 import {useQuery} from "@tanstack/react-query";
 import useApiAuthContext from "../hooks/useApiAuthContext.ts";
 import SourcesPanel from "../components/dashboard/sourcesPanel.tsx";
 import {SelectChangeEvent} from "@mui/material";
-import {getDefaultInfo} from "../lib/api/getDefaultInfo.ts";
+import {getDefaultInfo} from "../lib/api/connection/getDefaultInfo.ts";
+import {getRedisInfo} from "../lib/api/connection/getRedisInfo.ts";
+import {useSearchParams} from "react-router-dom";
+import ElasticsearchStatsPanel from "../components/dashboard/elasticsearchStatsPanel.tsx";
 
-export interface ISources {
-    id: number,
+export interface ISource {
     label: string,
     connectionStatus: "success" | "pending" | "idle" | "error",
-    testConnection: () => void
+    testConnection: () => void,
+    isClickable: boolean
 }
 
 export default function DashboardPage() {
@@ -29,35 +32,77 @@ export default function DashboardPage() {
 
     const {status: queueStatus, testConnection: testQueue} = useConnection({mutationFn: getQueueStats})
     const {status: elasticsearchStatus, testConnection: testElasticsearch} = useConnection({mutationFn: getDefaultInfo})
+    const {status: redisStatus, testConnection: testRedis} = useConnection({mutationFn: getRedisInfo})
 
-    const {data: statsPanelResponse, status: statsPanelStatus, fetchStatus: statsPanelFetchStatus} = useQuery({
+    const {
+        data: queueStatsPanelResponse,
+        status: queueStatsPanelStatus,
+        fetchStatus: queueStatsPanelFetchStatus
+    } = useQuery({
         queryKey: ["queueStats"], queryFn: () => {
             return getQueueStats({prefixUrl: apiPrefix, accessToken})
-        }, refetchInterval: refetchInterval
+        }, refetchInterval
     })
 
-    const baseSources = [{
-        id: 1,
-        label: "Elasticsearch",
-        connectionStatus: elasticsearchStatus,
-        testConnection: testElasticsearch
-    }, {
-        id: 2,
-        label: "Queue",
-        connectionStatus: queueStatus,
-        testConnection: testQueue
-    }]
-    const [sources, setSources] = useState<ISources[]>(baseSources)
+    const {
+        data: elasticsearchStatsResponse,
+        status: elasticsearchStatsStatus,
+        fetchStatus: elasticsearchStatsFetchStatus
+    } = useQuery({
+        queryKey: ["elasticsearchStats"], queryFn: () => {
+            return getDefaultInfo({prefixUrl: apiPrefix, accessToken})
+        }, refetchInterval
+    })
+
+    const
+        baseSources: ISource[] = useMemo(() => {
+            return [{
+                label: "Elasticsearch",
+                connectionStatus: elasticsearchStatus,
+                testConnection: testElasticsearch,
+                isClickable: true
+            }, {
+                label: "Queue",
+                connectionStatus: queueStatus,
+                testConnection: testQueue,
+                isClickable: true
+            }, {
+                label: "Redis",
+                connectionStatus: redisStatus,
+                testConnection: testRedis,
+                isClickable: false
+            }]
+        }, [queueStatus, redisStatus, elasticsearchStatus])
+    const [sources, setSources] = useState<ISource[]>(baseSources)
+
+    const [searchParams, setSearchParams] = useSearchParams()
+    const defaultSelectedSource = "Queue"
+
+    if (!searchParams.get("source")) {
+        setSearchParams(prev => {
+            return {
+                ...prev,
+                source: defaultSelectedSource
+            }
+        })
+    }
+
+    const selectedSource = searchParams.get("source")
 
     useEffect(() => {
         setSources(baseSources)
-    }, [queueStatus, elasticsearchStatus]);
+    }, [baseSources]);
 
     return (
         <Box sx={{m: 0, p: 2, width: "100%", height: "100%", display: "flex", gap: "2rem"}}>
             <SourcesPanel sources={sources}/>
-            <StatsPanel status={statsPanelStatus} data={statsPanelResponse} maxRate={10000} refreshData={refreshData}
-                        fetchStatus={statsPanelFetchStatus}/>
+            {selectedSource === "Queue" &&
+                <QueueStatsPanel status={queueStatsPanelStatus} data={queueStatsPanelResponse} maxRate={10000}
+                                 refreshData={refreshData}
+                                 fetchStatus={queueStatsPanelFetchStatus}/>}
+            {selectedSource == "Elasticsearch" &&
+                <ElasticsearchStatsPanel status={elasticsearchStatsStatus} fetchStatus={elasticsearchStatsFetchStatus}
+                                         data={elasticsearchStatsResponse} refreshData={refreshData}/>}
         </Box>
     )
 }

--- a/src/pages/dashboardPage.tsx
+++ b/src/pages/dashboardPage.tsx
@@ -76,7 +76,7 @@ export default function DashboardPage() {
     const [sources, setSources] = useState<ISource[]>(baseSources)
 
     const [searchParams, setSearchParams] = useSearchParams()
-    const defaultSelectedSource = "Queue"
+    const defaultSelectedSource = baseSources[0].label
 
     if (!searchParams.get("source")) {
         setSearchParams(prev => {

--- a/src/types/ui/statsPanel.d.ts
+++ b/src/types/ui/statsPanel.d.ts
@@ -1,0 +1,12 @@
+import {SelectChangeEvent} from "@mui/material";
+
+export interface IStatsPanel<TData> {
+    status: "success" | "pending" | "error",
+    fetchStatus: "fetching" | "idle" | "paused"
+    data: TData,
+}
+
+export interface IRefreshData {
+    time: number,
+    onChange: (e: SelectChangeEvent<number>) => void
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
Add elasticsearch and redis to sources in dashboard page

- add list with information about elasticsearch cluster
- now you can select source to obtain information about the selected source in the panel

 - [X] I hereby declare this contribution to be licensed under the [MIT license](https://opensource.org/licenses/MIT)
 - [X] I hereby declare that I have read The Contributor License Agreement [CLA](contributor_license_agreement.md)

